### PR TITLE
Add support for task duration parsing and creation

### DIFF
--- a/alfredo-go/cmd/create.go
+++ b/alfredo-go/cmd/create.go
@@ -24,11 +24,19 @@ var createCmd = &cobra.Command{
 		myDueLang := os.Getenv("myDueLang")
 		myDeadline := os.Getenv("myDeadline")
 		myPriorityStr := os.Getenv("myPriority")
+		myDurationMinutesStr := os.Getenv("myDurationMinutes")
 
 		priority := 1
 		if myPriorityStr != "" {
 			if p, err := strconv.Atoi(myPriorityStr); err == nil {
 				priority = p
+			}
+		}
+
+		durationMinutes := 0
+		if myDurationMinutesStr != "" {
+			if d, err := strconv.Atoi(myDurationMinutesStr); err == nil {
+				durationMinutes = d
 			}
 		}
 
@@ -50,7 +58,7 @@ var createCmd = &cobra.Command{
 			}
 		}
 
-		err := taskService.CreateTask(taskText, taskLabels, taskProjectID, taskSectionID, myDueDate, myDueString, myDueLang, priority, myDeadline, deadlineLang)
+		err := taskService.CreateTask(taskText, taskLabels, taskProjectID, taskSectionID, myDueDate, myDueString, myDueLang, priority, myDeadline, deadlineLang, durationMinutes)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error creating task: %v\n", err)
 			fmt.Println("❌ server error\ncheck debugger")

--- a/alfredo-go/internal/parser/input.go
+++ b/alfredo-go/internal/parser/input.go
@@ -12,6 +12,7 @@ import (
 
 var inputPattern = regexp.MustCompile(`\s*([@#]\([^)]+\)|\S+)\s*`)
 var deadlinePattern = regexp.MustCompile(`\{([^}]+)\}`)
+var durationPattern = regexp.MustCompile(`(?i)\bfor\s+(\d+)\s*(minutes?|mins?|m|hours?|hrs?|h)\b`)
 
 // ParseInput tokenizes user input, keeping together elements with spaces if they are
 // in parentheses and preceded by # or @
@@ -26,30 +27,31 @@ func ParseInput(input string) []string {
 
 // ParsedTask holds the result of parsing a new-task input string
 type ParsedTask struct {
-	Content      string
-	Labels       []string
-	ProjectName  string // includes # prefix
-	ProjectID    string
-	SectionName  string
-	SectionID    string
-	DueDate      string
-	DueString    string // raw natural language text (e.g., "tomorrow")
-	DueLang      string // language for Todoist NLP (e.g., "en")
-	Deadline     string // resolved deadline date (YYYY-MM-DD)
-	DeadlineRaw  string // raw deadline text for NLP (e.g., "friday")
-	Priority     int    // Todoist API priority (4=highest, 1=lowest)
-	PrioString   string
-	RawInput     string
+	Content         string
+	Labels          []string
+	ProjectName     string // includes # prefix
+	ProjectID       string
+	SectionName     string
+	SectionID       string
+	DueDate         string
+	DueString       string // raw natural language text (e.g., "tomorrow")
+	DueLang         string // language for Todoist NLP (e.g., "en")
+	Deadline        string // resolved deadline date (YYYY-MM-DD)
+	DeadlineRaw     string // raw deadline text for NLP (e.g., "friday")
+	Priority        int    // Todoist API priority (4=highest, 1=lowest)
+	PrioString      string
+	DurationMinutes int // duration amount in minutes (e.g., 30)
+	RawInput        string
 }
 
 // InputContext holds contextual data needed during parsing
 type InputContext struct {
-	AllLabels     []string        // prefixed with @
-	AllProjects   []string        // prefixed with #
-	LabelCounts   map[string]int  // label name (no prefix) -> count
-	ProjectCounts map[string]int  // project name (no prefix) -> count
+	AllLabels     []string       // prefixed with @
+	AllProjects   []string       // prefixed with #
+	LabelCounts   map[string]int // label name (no prefix) -> count
+	ProjectCounts map[string]int // project name (no prefix) -> count
 	PartialMatch  bool
-	Lang          string          // system language code (e.g., "it", "de", "en")
+	Lang          string // system language code (e.g., "it", "de", "en")
 }
 
 // ParseNewTaskInput parses raw input for new task creation.
@@ -235,17 +237,51 @@ func ParseNewTaskInput(input string, ctx *InputContext) (*ParsedTask, []Autocomp
 
 	parsed.Content = strings.Join(taskElements, " ")
 
+	// Try to extract duration first, but don't remove it from content yet
+	var potentialDuration int
+	var contentWithoutDuration string
+	if parsed.Content != "" {
+		potentialDuration, contentWithoutDuration = extractDuration(parsed.Content)
+	}
+
 	// Inline date detection: if no explicit due: was set, try NLP on the content
-	if parsed.DueDate == "" && parsed.Content != "" {
-		if nlp := ParseNaturalDateInText(parsed.Content, lang); nlp != nil {
+	// Use content WITHOUT duration for better NLP parsing
+	contentForNLP := parsed.Content
+	if potentialDuration > 0 {
+		contentForNLP = contentWithoutDuration
+	}
+
+	if parsed.DueDate == "" && contentForNLP != "" {
+		if nlp := ParseNaturalDateInText(contentForNLP, lang); nlp != nil {
 			parsed.DueDate = FormatResolvedDate(nlp.Time)
-			// Strip matched date text from content
-			cleaned := parsed.Content[:nlp.Start] + parsed.Content[nlp.End:]
-			cleaned = strings.TrimSpace(cleaned)
-			for strings.Contains(cleaned, "  ") {
-				cleaned = strings.ReplaceAll(cleaned, "  ", " ")
+
+			// Check if we should apply duration
+			// Duration applies when: parsed date has time component AND includes actual date (not just time)
+			shouldApplyDuration := potentialDuration > 0 && isDueDateWithTime(parsed.DueDate) && hasActualDate(nlp.Text)
+
+			// Use cleaned content if we're applying duration, otherwise keep original
+			if shouldApplyDuration {
+				// Strip matched date text from cleaned content (without duration)
+				cleaned := contentForNLP[:nlp.Start] + contentForNLP[nlp.End:]
+				cleaned = strings.TrimSpace(cleaned)
+				// Remove orphaned prepositions (at, on, by, etc.)
+				cleaned = cleanupOrphanedPrepositions(cleaned)
+				for strings.Contains(cleaned, "  ") {
+					cleaned = strings.ReplaceAll(cleaned, "  ", " ")
+				}
+				parsed.Content = cleaned
+				parsed.DurationMinutes = potentialDuration
+			} else {
+				// Don't apply duration, use original content and strip only the date
+				cleaned := parsed.Content[:nlp.Start] + parsed.Content[nlp.End:]
+				cleaned = strings.TrimSpace(cleaned)
+				// Remove orphaned prepositions (at, on, by, etc.)
+				cleaned = cleanupOrphanedPrepositions(cleaned)
+				for strings.Contains(cleaned, "  ") {
+					cleaned = strings.ReplaceAll(cleaned, "  ", " ")
+				}
+				parsed.Content = cleaned
 			}
-			parsed.Content = cleaned
 		}
 	}
 
@@ -378,4 +414,116 @@ func itoa(n int) string {
 		s = "-" + s
 	}
 	return s
+}
+
+// isDueDateWithTime checks if the due date string includes a time component
+func isDueDateWithTime(dueDate string) bool {
+	// Due dates with time typically contain 'T' (ISO 8601) or time indicators
+	return strings.Contains(dueDate, "T") || strings.Contains(dueDate, ":")
+}
+
+// cleanupOrphanedPrepositions removes trailing prepositions left after date extraction
+func cleanupOrphanedPrepositions(content string) string {
+	// Common prepositions that might be left behind after date extraction
+	orphanedPreps := []string{" at", " on", " by", " in", " from", " to"}
+
+	for _, prep := range orphanedPreps {
+		if strings.HasSuffix(content, prep) {
+			content = strings.TrimSuffix(content, prep)
+			content = strings.TrimSpace(content)
+		}
+	}
+
+	return content
+}
+
+// hasActualDate checks if the NLP matched text is meaningful for duration extraction
+// Returns true if it contains date keywords OR time indicators (since time implies "today")
+func hasActualDate(nlpText string) bool {
+	lower := strings.ToLower(nlpText)
+	// Check for date keywords (day names, relative dates, etc.)
+	dateKeywords := []string{
+		"today", "tomorrow", "yesterday",
+		"monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday",
+		"next", "last", "week", "month", "day",
+		"jan", "feb", "mar", "apr", "may", "jun", "jul", "aug", "sep", "oct", "nov", "dec",
+	}
+
+	for _, keyword := range dateKeywords {
+		if strings.Contains(lower, keyword) {
+			return true
+		}
+	}
+
+	// Also return true if it contains time indicators (am/pm, colons)
+	// because time-only inputs like "5pm" implicitly mean "today at 5pm"
+	timePattern := regexp.MustCompile(`(?i)\d{1,2}(:\d{2})?\s*(am|pm)|\d{1,2}:\d{2}`)
+	return timePattern.MatchString(nlpText)
+}
+
+// extractDuration extracts duration from content and returns (minutes, cleanedContent)
+// Supports formats like "30 minutes", "2h", "2h15m", etc.
+func extractDuration(content string) (int, string) {
+	// Pattern matches "for X minutes/hours" with various formats
+	// e.g., "for 30 minutes", "for 2h", "for 2h15m"
+
+	// First, try to match combined format like "2h15m"
+	combinedPattern := regexp.MustCompile(`(?i)\bfor\s+(?:(\d+)\s*h(?:ours?|rs?)?)?(?:\s*(\d+)\s*m(?:inutes?|ins?)?)?`)
+	if m := combinedPattern.FindStringSubmatchIndex(content); m != nil {
+		matchStart, matchEnd := m[0], m[1]
+		hoursIdx, minutesIdx := m[2], m[4]
+
+		totalMinutes := 0
+
+		// Extract hours if present
+		if hoursIdx != -1 {
+			hoursStr := content[hoursIdx:m[3]]
+			if hours, err := strconv.Atoi(hoursStr); err == nil {
+				totalMinutes += hours * 60
+			}
+		}
+
+		// Extract minutes if present
+		if minutesIdx != -1 {
+			minutesStr := content[minutesIdx:m[5]]
+			if minutes, err := strconv.Atoi(minutesStr); err == nil {
+				totalMinutes += minutes
+			}
+		}
+
+		if totalMinutes > 0 {
+			// Remove the duration text from content
+			cleaned := content[:matchStart] + content[matchEnd:]
+			cleaned = strings.TrimSpace(cleaned)
+			for strings.Contains(cleaned, "  ") {
+				cleaned = strings.ReplaceAll(cleaned, "  ", " ")
+			}
+			return totalMinutes, cleaned
+		}
+	}
+
+	// Fallback to simple single-unit pattern
+	if m := durationPattern.FindStringSubmatch(content); m != nil {
+		amount, _ := strconv.Atoi(m[1])
+		unit := strings.ToLower(m[2])
+
+		minutes := 0
+		switch {
+		case strings.HasPrefix(unit, "h"):
+			minutes = amount * 60
+		case strings.HasPrefix(unit, "m"):
+			minutes = amount
+		}
+
+		if minutes > 0 {
+			cleaned := durationPattern.ReplaceAllString(content, "")
+			cleaned = strings.TrimSpace(cleaned)
+			for strings.Contains(cleaned, "  ") {
+				cleaned = strings.ReplaceAll(cleaned, "  ", " ")
+			}
+			return minutes, cleaned
+		}
+	}
+
+	return 0, content
 }

--- a/alfredo-go/internal/parser/input.go
+++ b/alfredo-go/internal/parser/input.go
@@ -468,7 +468,7 @@ func extractDuration(content string) (int, string) {
 	// e.g., "for 30 minutes", "for 2h", "for 2h15m"
 
 	// First, try to match combined format like "2h15m"
-	combinedPattern := regexp.MustCompile(`(?i)\bfor\s+(?:(\d+)\s*h(?:ours?|rs?)?)?(?:\s*(\d+)\s*m(?:inutes?|ins?)?)?`)
+	combinedPattern := regexp.MustCompile(`(?i)\bfor\s+(?:(\d+)\s*h(?:ours?|rs?)?)?(?:\s*(\d+)\s*m(?:inutes?|ins?)?)?\b`)
 	if m := combinedPattern.FindStringSubmatchIndex(content); m != nil {
 		matchStart, matchEnd := m[0], m[1]
 		hoursIdx, minutesIdx := m[2], m[4]

--- a/alfredo-go/internal/parser/input_test.go
+++ b/alfredo-go/internal/parser/input_test.go
@@ -368,3 +368,218 @@ func TestParseNewTaskInputInlineNLP(t *testing.T) {
 		t.Errorf("DueDate should be empty for 'buy milk', got %q", parsed.DueDate)
 	}
 }
+
+func TestExtractDuration(t *testing.T) {
+	tests := []struct {
+		name            string
+		content         string
+		expectedMinutes int
+		expectedContent string
+	}{
+		{
+			name:            "30 minutes",
+			content:         "Do something for 30 minutes",
+			expectedMinutes: 30,
+			expectedContent: "Do something",
+		},
+		{
+			name:            "30m",
+			content:         "Do something for 30m",
+			expectedMinutes: 30,
+			expectedContent: "Do something",
+		},
+		{
+			name:            "2 hours",
+			content:         "Do something for 2 hours",
+			expectedMinutes: 120,
+			expectedContent: "Do something",
+		},
+		{
+			name:            "2h",
+			content:         "Do something for 2h",
+			expectedMinutes: 120,
+			expectedContent: "Do something",
+		},
+		{
+			name:            "2h15m",
+			content:         "Do something for 2h15m",
+			expectedMinutes: 135,
+			expectedContent: "Do something",
+		},
+		{
+			name:            "2h 15m",
+			content:         "Do something for 2h 15m",
+			expectedMinutes: 135,
+			expectedContent: "Do something",
+		},
+		{
+			name:            "3 hours",
+			content:         "Do something for 3 hours",
+			expectedMinutes: 180,
+			expectedContent: "Do something",
+		},
+		{
+			name:            "no duration",
+			content:         "Do something",
+			expectedMinutes: 0,
+			expectedContent: "Do something",
+		},
+		{
+			name:            "1 hour 30 minutes",
+			content:         "Meeting for 1 hour 30 minutes",
+			expectedMinutes: 90,
+			expectedContent: "Meeting",
+		},
+		{
+			name:            "45 mins",
+			content:         "Call for 45 mins",
+			expectedMinutes: 45,
+			expectedContent: "Call",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			minutes, content := extractDuration(tt.content)
+			if minutes != tt.expectedMinutes {
+				t.Errorf("extractDuration(%q) minutes = %d, want %d", tt.content, minutes, tt.expectedMinutes)
+			}
+			if content != tt.expectedContent {
+				t.Errorf("extractDuration(%q) content = %q, want %q", tt.content, content, tt.expectedContent)
+			}
+		})
+	}
+}
+
+func TestIsDueDateWithTime(t *testing.T) {
+	tests := []struct {
+		name     string
+		dueDate  string
+		expected bool
+	}{
+		{
+			name:     "ISO 8601 with time",
+			dueDate:  "2025-05-06T17:00:00",
+			expected: true,
+		},
+		{
+			name:     "date with colon time",
+			dueDate:  "2025-05-06 17:00",
+			expected: true,
+		},
+		{
+			name:     "date only",
+			dueDate:  "2025-05-06",
+			expected: false,
+		},
+		{
+			name:     "empty string",
+			dueDate:  "",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isDueDateWithTime(tt.dueDate)
+			if result != tt.expected {
+				t.Errorf("isDueDateWithTime(%q) = %v, want %v", tt.dueDate, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestParseNewTaskInputWithDuration(t *testing.T) {
+	ctx := &InputContext{
+		AllLabels:     []string{},
+		AllProjects:   []string{},
+		LabelCounts:   map[string]int{},
+		ProjectCounts: map[string]int{},
+		PartialMatch:  true,
+		Lang:          "en",
+	}
+
+	tests := []struct {
+		name            string
+		input           string
+		expectedContent string
+		expectedMinutes int
+		hasDueDateTime  bool
+	}{
+		{
+			name:            "tomorrow at 5pm for 30 minutes",
+			input:           "Do something tomorrow at 5pm for 30 minutes",
+			expectedContent: "Do something",
+			expectedMinutes: 30,
+			hasDueDateTime:  true,
+		},
+		{
+			name:            "tomorrow at 5pm for 30m",
+			input:           "Do something tomorrow at 5pm for 30m",
+			expectedContent: "Do something",
+			expectedMinutes: 30,
+			hasDueDateTime:  true,
+		},
+		{
+			name:            "at 5pm for 2h tomorrow",
+			input:           "Do something at 5pm for 2h tomorrow",
+			expectedContent: "Do something",
+			expectedMinutes: 120,
+			hasDueDateTime:  true,
+		},
+		{
+			name:            "at 5pm for 2h15m tomorrow",
+			input:           "Do something at 5pm for 2h15m tomorrow",
+			expectedContent: "Do something",
+			expectedMinutes: 135,
+			hasDueDateTime:  true,
+		},
+		{
+			name:            "for 3 hours tomorrow at 5pm",
+			input:           "Do something for 3 hours tomorrow at 5pm",
+			expectedContent: "Do something",
+			expectedMinutes: 180,
+			hasDueDateTime:  true,
+		},
+		{
+			name:            "tomorrow for 30m (no time, no duration extraction)",
+			input:           "Do something tomorrow for 30m",
+			expectedContent: "Do something for 30m",
+			expectedMinutes: 0,
+			hasDueDateTime:  false,
+		},
+		{
+			name:            "at 5pm for 1h (today)",
+			input:           "Do something at 5pm for 1h",
+			expectedContent: "Do something",
+			expectedMinutes: 60,
+			hasDueDateTime:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parsed, _, needsExit := ParseNewTaskInput(tt.input, ctx)
+			if needsExit {
+				t.Fatal("expected no exit")
+			}
+
+			if parsed.Content != tt.expectedContent {
+				t.Errorf("Content = %q, want %q", parsed.Content, tt.expectedContent)
+			}
+
+			if tt.hasDueDateTime {
+				if parsed.DueDate == "" {
+					t.Error("DueDate should not be empty")
+				}
+				if !isDueDateWithTime(parsed.DueDate) {
+					t.Errorf("DueDate %q should contain time component", parsed.DueDate)
+				}
+			}
+
+			if parsed.DurationMinutes != tt.expectedMinutes {
+				t.Errorf("DurationMinutes = %d, want %d", parsed.DurationMinutes, tt.expectedMinutes)
+			}
+		})
+	}
+}

--- a/alfredo-go/internal/service/task_service.go
+++ b/alfredo-go/internal/service/task_service.go
@@ -570,26 +570,32 @@ func (s *TaskService) ParseNewTask(input string) (*alfred.Output, error) {
 		deadlineStringF = "🎯 deadline:" + parsed.Deadline
 	}
 
+	var durationStringF string
+	if parsed.DurationMinutes > 0 {
+		durationStringF = fmt.Sprintf("⏱️ %dm", parsed.DurationMinutes)
+	}
+
 	projStringF := "📋" + parsed.ProjectName
 
-	subtitle := fmt.Sprintf("%s %s %s %s %s %s ⇧↩️ to create",
-		projStringF, sectStringF, tagStringF, prioStringF, dueStringF, deadlineStringF)
+	subtitle := fmt.Sprintf("%s %s %s %s %s %s %s ⇧↩️ to create",
+		projStringF, sectStringF, tagStringF, prioStringF, dueStringF, deadlineStringF, durationStringF)
 
 	output.Items = append(output.Items, alfred.OutputItem{
 		Title:    parsed.Content,
 		Subtitle: subtitle,
 		Arg:      input,
 		Variables: map[string]any{
-			"myTaskText":    parsed.Content,
-			"myTagString":   tagString,
-			"myProjectID":   parsed.ProjectID,
-			"mySectionID":   parsed.SectionID,
-			"myDueDate":     parsed.DueDate,
-			"myDueString":   parsed.DueString,
-			"myDueLang":     parsed.DueLang,
-			"myDeadline":    parsed.Deadline,
-			"myDeadlineRaw": parsed.DeadlineRaw,
-			"myPriority":    parsed.Priority,
+			"myTaskText":       parsed.Content,
+			"myTagString":      tagString,
+			"myProjectID":      parsed.ProjectID,
+			"mySectionID":      parsed.SectionID,
+			"myDueDate":        parsed.DueDate,
+			"myDueString":      parsed.DueString,
+			"myDueLang":        parsed.DueLang,
+			"myDeadline":       parsed.Deadline,
+			"myDeadlineRaw":    parsed.DeadlineRaw,
+			"myPriority":       parsed.Priority,
+			"myDurationMinutes": parsed.DurationMinutes,
 		},
 		Icon: &alfred.Icon{Path: "icons/newTask.png"},
 	})
@@ -622,7 +628,7 @@ func (s *TaskService) DeleteTask(taskID string) error {
 }
 
 // CreateTask creates a new task via the API
-func (s *TaskService) CreateTask(content, labelsStr, projectID, sectionID, dueDate, dueString, dueLang string, priority int, deadline, deadlineLang string) error {
+func (s *TaskService) CreateTask(content, labelsStr, projectID, sectionID, dueDate, dueString, dueLang string, priority int, deadline, deadlineLang string, durationMinutes int) error {
 	var labels []string
 	if labelsStr != "" {
 		labels = strings.Split(labelsStr, ",,..,,")
@@ -648,7 +654,7 @@ func (s *TaskService) CreateTask(content, labelsStr, projectID, sectionID, dueDa
 			time.Now().Format("Monday, January 2, 2006, 3:04:05 pm"))
 	}
 
-	if err := s.client.CreateTask(content, labels, projectID, sectionID, dueDate, dueString, dueLang, priority, dl, description); err != nil {
+	if err := s.client.CreateTask(content, labels, projectID, sectionID, dueDate, dueString, dueLang, priority, dl, description, durationMinutes); err != nil {
 		return err
 	}
 

--- a/alfredo-go/pkg/todoist/client.go
+++ b/alfredo-go/pkg/todoist/client.go
@@ -183,7 +183,7 @@ func (c *Client) DeleteTask(taskID string) error {
 }
 
 // CreateTask creates a new task via the REST API
-func (c *Client) CreateTask(content string, labels []string, projectID, sectionID, dueDate, dueString, dueLang string, priority int, deadline *Deadline, description string) error {
+func (c *Client) CreateTask(content string, labels []string, projectID, sectionID, dueDate, dueString, dueLang string, priority int, deadline *Deadline, description string, durationMinutes int) error {
 	payload := map[string]any{
 		"content":  content,
 		"priority": priority,
@@ -218,6 +218,10 @@ func (c *Client) CreateTask(content string, labels []string, projectID, sectionI
 		if deadline.Lang != "" {
 			payload["deadline_lang"] = deadline.Lang
 		}
+	}
+	if durationMinutes > 0 {
+		payload["duration"] = durationMinutes
+		payload["duration_unit"] = "minute"
 	}
 
 	body, err := json.Marshal(payload)


### PR DESCRIPTION
Hi, happy to have this rejected if contributions aren't welcome — no pressure!

This PR adds support for specifying task duration directly in Alfred's new task input using natural language (e.g., "for 30 minutes", "for 2h"). Duration is extracted via NLP and passed to the Todoist API.

To avoid incorrect scheduling, duration is only applied when the task also includes a due date with a time component.

Note: English only. AI-assisted implementation.