### PR TITLE
Add sign and release Makefile targets

### DIFF
--- a/alfredo-go/Makefile
+++ b/alfredo-go/Makefile
@@ -1,4 +1,10 @@
-.PHONY: build clean test run install deps build-universal build-workflow
+.PHONY: build clean test run install deps build-universal build-workflow sign release
+
+# Code signing / notarization config (override on the command line if needed)
+SIGN_IDENTITY  ?= C85516732AD930BB84E217AFF2C375E64268B111
+NOTARY_PROFILE ?= gio-notarytool
+WORKFLOW_DIR   ?= ../source
+BINARY         ?= alfredo-go
 
 # Build the application
 build:
@@ -14,6 +20,18 @@ build-universal:
 # Build and copy binary into the Alfred workflow directory
 build-workflow: build-universal
 	cp alfredo-go ../source/alfredo-go
+
+# Sign and notarize the binary in the Alfred workflow directory
+sign:
+	cd $(WORKFLOW_DIR) && \
+		codesign -s $(SIGN_IDENTITY) -o runtime -v $(BINARY) && \
+		zip $(BINARY).zip $(BINARY) && \
+		xcrun notarytool submit $(BINARY).zip --keychain-profile "$(NOTARY_PROFILE)" --wait --verbose && \
+		rm -f $(BINARY).zip && \
+		codesign --display --verbose=4 $(BINARY)
+
+# Full release: build universal binary, copy into workflow, then sign + notarize
+release: build-workflow sign
 
 # Build for different platforms
 build-all:
@@ -57,6 +75,8 @@ help:
 	@echo "  build           - Build the application"
 	@echo "  build-universal - Build universal macOS binary (amd64+arm64)"
 	@echo "  build-workflow  - Build and copy binary into Alfred workflow"
+	@echo "  sign            - Sign + notarize the binary in the workflow dir"
+	@echo "  release         - build-workflow then sign + notarize"
 	@echo "  build-all       - Build for multiple platforms"
 	@echo "  deps            - Install dependencies"
 	@echo "  test            - Run tests"


### PR DESCRIPTION
## Summary
Captures the code-signing + notarization flow in the repo so workflow releases are reproducible, instead of relying on out-of-repo notes.

- **`sign`** — codesigns the binary in `../source` with hardened runtime (`-o runtime`), zips, submits to `xcrun notarytool` (keychain profile `gio-notarytool`), cleans up, and verifies.
- **`release`** — chains `build-workflow` + `sign` for a one-shot rebuild & ship.
- Signing identity, notarytool profile, workflow dir, and binary name are overridable Makefile variables.
- Help text updated.

Plain `make build` / `build-workflow` remain unsigned — only `sign`/`release` sign.

## Why
The shipped binary must be Developer-ID signed + notarized or Gatekeeper blocks it, but no signing step existed in the repo (the flow lived only in personal notes). After merging a source PR, the release is now just `make release`, then repackage the `.alfredworkflow` and bump the version.

## Test plan
- `make -n release` dry-run shows the correct command chain.
- `make help` lists the new targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)