### PR TITLE
Add CI workflow (build, vet, test)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build-test:
+    name: build & test
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: alfredo-go
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+          cache-dependency-path: alfredo-go/go.sum
+      - name: Build
+        run: go build ./...
+      - name: Vet
+        run: go vet ./...
+      - name: Test
+        run: go test ./...


### PR DESCRIPTION
Adds a GitHub Actions workflow that runs `go build`, `go vet`, and `go test` on the `alfredo-go` module for every push to `main` and every PR.

This gives a status check that can later be marked **required** in branch protection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)